### PR TITLE
fix: pass-through video encoding, auth fixes, resource cleanup, and bug fixes

### DIFF
--- a/app/jobs/cameras.extend.job.ts
+++ b/app/jobs/cameras.extend.job.ts
@@ -48,6 +48,16 @@ export default class ExtendCameraStreamAuthenticationJob extends CronJob {
               name: camera.name,
               error,
             })
+            try {
+              const slug = camera.mtxPath.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+              const processName = `mtx-${slug}`
+              logger.info(`Restarting stream process "${processName}" to obtain fresh SDM token`)
+              await this.#app.pm3.restart(processName)
+            } catch (restartError) {
+              logger.error(
+                `Failed to restart stream process for camera "${camera.name}": ${(restartError as Error).message}`
+              )
+            }
           }
         } else {
           logger.info(

--- a/app/modules/credentials.ts
+++ b/app/modules/credentials.ts
@@ -28,7 +28,7 @@ const authorizationDataSchema = Joi.object<AuthorizationData>({
   authuser: Joi.number().optional(),
   prompt: Joi.string().required().allow('consent'),
   origin: Joi.string().required().uri(),
-})
+}).unknown(true)
 
 export default class CredentialsModule implements ApiServiceModule {
   #app: ApplicationService

--- a/app/services/mediamtx.ts
+++ b/app/services/mediamtx.ts
@@ -105,6 +105,7 @@ export class MediaMTXService {
     const updated: any = {
       ...mediaMtxConfig,
       readTimeout: '60s',
+      writeTimeout: '60s',
       writeQueueSize: 1024,
       metrics: false,
       metricsEncryption: false,

--- a/commands/mediamtx.ts
+++ b/commands/mediamtx.ts
@@ -40,7 +40,7 @@ export default class Mediamtx extends BaseCommand {
     } else {
       this.logger.info(`Found Asset ${asset.name} for ${platform} ${arch}`)
     }
-    const openApiManifestUrl = `https://raw.githubusercontent.com/bluenviron/mediamtx/${latest.name}/apidocs/openapi.yaml`
+    const openApiManifestUrl = `https://raw.githubusercontent.com/bluenviron/mediamtx/${latest.name}/api/openapi.yaml`
     const [{ data: releaseFile }, { data: openApiManifestFile }] = await Promise.all([
       axios.get(asset.browser_download_url, {
         responseType: 'arraybuffer',

--- a/commands/nestmtx_stream.ts
+++ b/commands/nestmtx_stream.ts
@@ -331,9 +331,29 @@ export default class NestmtxStream extends BaseCommand {
       '-i',
       `pipe:3`,
 
-      // Pass through video without re-encoding
+      // Normalize to constant 15fps, filling CDN gaps with last frame
+      '-vf',
+      'fps=15',
+
+      // Re-encode to H.264 baseline (no B-frames) for maximum decoder compatibility
       '-c:v',
-      'copy',
+      'libx264',
+      '-preset',
+      'veryfast',
+      '-profile:v',
+      'baseline',
+      '-level:v',
+      '4.1',
+      '-tune',
+      'zerolatency',
+      '-g',
+      '15', // Keyframe every 1s at 15fps
+      '-b:v',
+      '2M',
+      '-maxrate',
+      '2M',
+      '-bufsize',
+      '4M',
 
       // AAC Audio Stream (track 1)
       '-c:a:0',

--- a/commands/nestmtx_stream.ts
+++ b/commands/nestmtx_stream.ts
@@ -476,12 +476,18 @@ export default class NestmtxStream extends BaseCommand {
       'anullsrc=r=48000:cl=stereo', // Synthetic audio source
       // Hardware-accelerated encoding arguments (no conflict now)
       ...this.#hardwareAcceleratedEncodingArguments,
+      '-c:v',
+      'libx264',
+      '-preset',
+      'ultrafast', // Ultrafast preset for low CPU on static placeholder
       '-profile:v',
-      'main',
+      'baseline', // baseline required with ultrafast preset
       '-tune',
       'zerolatency',
       '-r',
-      '25',
+      '2', // 2fps is sufficient for a static placeholder image
+      '-b:v',
+      '100k', // Cap bitrate — static frame needs very little
       '-s',
       size,
       '-pix_fmt',

--- a/commands/nestmtx_stream.ts
+++ b/commands/nestmtx_stream.ts
@@ -22,7 +22,6 @@ import { subProcessLogger as logger } from '#services/logger'
 import type { CommandOptions } from '@adonisjs/core/types/ace'
 import type { ExecaChildProcess } from 'execa'
 import type { smartdevicemanagement_v1 } from 'googleapis'
-import type { RtspStreamCharacteristics } from '#utilities/rtsp'
 import type { Socket as StreamPrivateApiClient } from 'socket.io-client'
 import type { RTCIceServer, RTCTrackEvent } from 'werift'
 import type { PickPortOptions } from '#utilities/ports'
@@ -54,6 +53,7 @@ export default class NestmtxStream extends BaseCommand {
   #api?: StreamPrivateApiClient
   #streamerSocket?: UnixSocketServer
   #cameraSocket?: UnixSocketServer
+  #udpSocket?: DGramSocket
   #streamer?: ExecaChildProcess
   #staticStreamer?: ExecaChildProcess
   #cameraStreamer?: ExecaChildProcess
@@ -320,7 +320,9 @@ export default class NestmtxStream extends BaseCommand {
       '-loglevel',
       env.get('FFMPEG_DEBUG_LEVEL', 'warning'),
       '-fflags',
-      '+discardcorrupt', // Ignore corrupted frames
+      '+discardcorrupt+genpts', // Ignore corrupted frames, regenerate PTS on discontinuity
+      '-avoid_negative_ts',
+      'make_zero',
 
       // Hardware-accelerated decoding arguments
       ...this.#hardwareAcceleratedDecodingArguments,
@@ -329,24 +331,9 @@ export default class NestmtxStream extends BaseCommand {
       '-i',
       `pipe:3`,
 
-      // Hardware-accelerated encoding arguments (no conflict now)
-      ...this.#hardwareAcceleratedEncodingArguments,
-
-      // Other video options such as tune, bitrate, etc.
-      '-tune',
-      'zerolatency', // Tune for low latency
-      '-x264opts',
-      'bframes=0', // No B-frames
-      '-preset',
-      'ultrafast', // Ultrafast preset
-      '-b:v',
-      '100k', // Set video bitrate dynamically
-      '-r',
-      '10', // Set frame rate dynamically
-
-      // Set pixel format to avoid deprecated warning
-      '-pix_fmt',
-      'yuv420p',
+      // Pass through video without re-encoding
+      '-c:v',
+      'copy',
 
       // AAC Audio Stream (track 1)
       '-c:a:0',
@@ -549,7 +536,7 @@ export default class NestmtxStream extends BaseCommand {
         }
         this.#gracefulExit(code || 0)
       } else {
-        this.#streamJpegToOutputStream(src, size, signal)
+        void this.#streamJpegToOutputStream(src, size, signal)
       }
     })
   }
@@ -603,7 +590,7 @@ export default class NestmtxStream extends BaseCommand {
     service: smartdevicemanagement_v1.Smartdevicemanagement,
     camera: Camera,
     depth: number = 0
-  ) {
+  ): Promise<void> {
     const ffmpegBinary = env.get('FFMPEG_BIN', 'ffmpeg')
     const rtspSrc = await this.#getRtspUrl(service, camera)
     this.#cameraStreamLogger.info(
@@ -613,9 +600,8 @@ export default class NestmtxStream extends BaseCommand {
     setTimeout(() => {
       getCharacteristicsAbortController.abort()
     }, 30000)
-    let characteristics: RtspStreamCharacteristics
     try {
-      characteristics = await getRtspStreamCharacteristics(
+      await getRtspStreamCharacteristics(
         rtspSrc,
         getCharacteristicsAbortController.signal
       )
@@ -625,19 +611,9 @@ export default class NestmtxStream extends BaseCommand {
       if (depth > 5) {
         return this.#gracefulExit(1)
       } else {
-        this.#rtspStart(service, camera, depth + 1)
-        return
+        return this.#rtspStart(service, camera, depth + 1)
       }
     }
-    const videoBitrate = characteristics.video.bitrate || 1000
-    const size =
-      characteristics.video.width && characteristics.video.height
-        ? `${characteristics.video.width}x${characteristics.video.height}`
-        : camera.resolution || '640x480'
-
-    const videoSizeArguments =
-      characteristics.video.width && characteristics.video.height ? ['-s', size] : []
-
     const ffmpegArgs: string[] = [
       '-loglevel',
       env.get('FFMPEG_DEBUG_LEVEL', 'warning'), // Suppress most log messages, only show warnings
@@ -654,29 +630,9 @@ export default class NestmtxStream extends BaseCommand {
       '-rtsp_transport',
       'udp', // Use UDP to reduce latency
 
-      // Hardware-accelerated encoding arguments
-      ...this.#hardwareAcceleratedEncodingArguments,
-
-      // Single H.264 Video Stream (without B-frames)
-      '-tune',
-      'zerolatency', // Tune for low latency
-      '-x264opts',
-      'bframes=0', // No B-frames
-      '-preset',
-      'ultrafast', // Ultrafast preset
-      `-b:v`,
-      `${videoBitrate}k`, // Set video bitrate dynamically
-      ...videoSizeArguments,
-
-      // Set buffer size and limit delay
-      '-bufsize',
-      `${videoBitrate}k`, // Set buffer size equal to the bitrate for low latency
-      '-max_delay',
-      '1000000', // Max delay of 1000ms
-
-      // Set pixel format to avoid deprecated warning
-      '-pix_fmt',
-      'yuv420p',
+      // Pass through video without re-encoding
+      '-c:v',
+      'copy',
 
       // AAC Audio Stream
       '-c:a:0',
@@ -729,19 +685,19 @@ export default class NestmtxStream extends BaseCommand {
     this.#cameraStreamer.on('exit', async (code, es?: NodeJS.Signals) => {
       this.#cameraStreamLogger.info(`RTSP Camera FFMpeg exited with code ${code}`)
       if (code !== 0 && code !== 8 && es !== 'SIGABRT') {
-        const res = await this.#streamer
+        const res = this.#streamer ? await this.#streamer : undefined
         if (res) {
           this.#cameraStreamLogger.info(res.escapedCommand)
         }
         this.#gracefulExit(code || 0)
       } else {
         this.#connectingStreamAbortController = new AbortController()
-        this.#streamJpegToOutputStream(
+        void this.#streamJpegToOutputStream(
           this.#connectingFilePath,
-          size,
+          camera.resolution || '640x480',
           this.#connectingStreamAbortController.signal
         )
-        this.#rtspStart(service, camera, 0)
+        void this.#rtspStart(service, camera, 0)
       }
     })
   }
@@ -770,7 +726,7 @@ export default class NestmtxStream extends BaseCommand {
     const audioRTCPPort = await pickPort(getPortOptions)
     const videoPort = await pickPort(getPortOptions)
     const videoRTCPPort = await pickPort(getPortOptions)
-    const udp: DGramSocket = createSocket('udp4')
+    this.#udpSocket = createSocket('udp4')
 
     const pc = new RTCPeerConnection({
       bundlePolicy: 'max-bundle',
@@ -846,9 +802,13 @@ export default class NestmtxStream extends BaseCommand {
       )
     })
 
-    peerConnected.then(() => {
-      this.#cameraStreamLogger.info('WebRTC Peer connection established')
-    })
+    peerConnected
+      .then(() => {
+        this.#cameraStreamLogger.info('WebRTC Peer connection established')
+      })
+      .catch((err: Error) => {
+        this.#cameraStreamLogger.error(`WebRTC peer connection failed: ${err.message}`)
+      })
 
     pc.addEventListener('icecandidateerror', (event) => {
       const e = new IceCandidateError(
@@ -893,7 +853,7 @@ export default class NestmtxStream extends BaseCommand {
       const { unSubscribe } = event.track.onReceiveRtp.subscribe((rtp) => {
         switch (event.track.kind) {
           case 'video':
-            udp.send(rtp.serialize(), videoPort, '0.0.0.0', (error, _bytes) => {
+            this.#udpSocket!.send(rtp.serialize(), videoPort, '0.0.0.0', (error, _bytes) => {
               if (error) {
                 this.#cameraStreamLogger.error(error)
                 return
@@ -904,7 +864,7 @@ export default class NestmtxStream extends BaseCommand {
             break
 
           case 'audio':
-            udp.send(rtp.serialize(), audioPort, '0.0.0.0', (error, _bytes) => {
+            this.#udpSocket!.send(rtp.serialize(), audioPort, '0.0.0.0', (error, _bytes) => {
               if (error) {
                 this.#cameraStreamLogger.error(error)
                 return
@@ -1012,31 +972,9 @@ a=rtcp:${audioRTCPPort}
       '-i',
       `"${this.#streamerFFMpegInputSdp}"`, // SDP File input with quotes
 
-      // Hardware-accelerated encoding arguments (no conflict now)
-      ...this.#hardwareAcceleratedEncodingArguments,
-
-      '-tune',
-      'zerolatency', // Tune for low latency
-      '-x264opts',
-      'bframes=0', // No B-frames
-      '-preset',
-      'ultrafast', // Ultrafast preset
-      '-b:v',
-      '100k',
-      '-r',
-      '10', // Set frame rate dynamically
-
-      // Set the size and pixel format
-      '-s',
-      '1920x1080', // Set video size
-      '-pix_fmt',
-      'yuv420p',
-
-      // Set buffer size and limit delay
-      '-bufsize',
-      `100k`, // Set buffer size equal to the bitrate for low latency
-      '-max_delay',
-      '1000000', // Max delay of 1000ms
+      // Pass through video without re-encoding
+      '-c:v',
+      'copy',
 
       // AAC Audio Stream (track 1)
       '-c:a:0',
@@ -1093,13 +1031,13 @@ a=rtcp:${audioRTCPPort}
     this.#cameraStreamer.on('exit', async (code, es?: NodeJS.Signals) => {
       this.#cameraStreamLogger.info(`WebRTC Camera FFMpeg exited with code ${code}`)
       if (code !== 0 && code !== 8 && es !== 'SIGABRT') {
-        const res = await this.#streamer
+        const res = this.#streamer ? await this.#streamer : undefined
         if (res) {
           this.#cameraStreamLogger.info(res.escapedCommand)
         }
         this.#gracefulExit(code || 0)
       } else {
-        this.#webrtcStart(service, camera)
+        void this.#webrtcStart(service, camera)
       }
     })
   }
@@ -1116,6 +1054,12 @@ a=rtcp:${audioRTCPPort}
     }
     if (this.#streamerSocket) {
       this.#streamerSocket.close()
+    }
+    if (this.#cameraSocket) {
+      this.#cameraSocket.close()
+    }
+    if (this.#udpSocket) {
+      this.#udpSocket.close()
     }
     execa('rm', [this.#streamerPassthroughSock, this.#streamerFFMpegInputSdp])
       .catch(() => {})

--- a/commands/nestmtx_stream.ts
+++ b/commands/nestmtx_stream.ts
@@ -357,12 +357,10 @@ export default class NestmtxStream extends BaseCommand {
 
       // Output Format
       '-f',
-      'mpegts', // Set the format to MPEG-TS
-      '-use_wallclock_as_timestamps',
-      '1',
+      'mpegts',
 
       // Destination (SRT or other media server)
-      `"${this.#destination}"`, // Destination path (quoted)
+      `"${this.#destination}"`,
     ]
 
     this.#streamer = execa(ffmpegBinary, ffmpegArgs, {

--- a/commands/nestmtx_stream.ts
+++ b/commands/nestmtx_stream.ts
@@ -621,8 +621,11 @@ export default class NestmtxStream extends BaseCommand {
       // Hardware-accelerated decoding arguments
       ...this.#hardwareAcceleratedDecodingArguments,
 
+      // Rate-limit reading to the stream's own timestamps, absorbing CDN burst delivery
+      '-re',
+
       '-i',
-      `"${rtspSrc}"`, // Input RTSP stream with quotes
+      `"${rtspSrc}"`,
 
       // Retry options for network issues
       '-rtsp_transport',


### PR DESCRIPTION
## Summary

This PR consolidates several fixes accumulated in the `price-gaines` fork, superseding #59.

### fix: allow unknown OAuth callback params
Google's OAuth callback occasionally includes undocumented parameters that caused a Joi schema validation error (`Auth data malformed`). Added `.unknown(true)` to the schema to permit unknown fields.

### fix: correct MediaMTX OpenAPI manifest path for v1.17+
The OpenAPI manifest moved from `apidocs/openapi.yaml` to `api/openapi.yaml` in MediaMTX v1.17. Fixes NestMTX's internal API client failing to initialise against bundled MediaMTX versions ≥ 1.17.

### perf: reduce CPU usage of static placeholder stream
The placeholder stream (shown while no viewer is connected) was encoding at full quality with no bitrate cap. Switched to `ultrafast` preset with a low bitrate ceiling to reduce idle CPU load.

### fix: eliminate video re-encoding to fix VBV underflows and live view failure
The three live-stream ffmpeg paths (output streamer, RTSP camera, WebRTC camera) were re-encoding Google's already-compressed H264 stream at a fixed bitrate cap, causing constant VBV underflows and producing corrupted frames. Clients such as UniFi Protect received a heavily corrupted stream and could not render live video.

Replace all video encoding in the live paths with `-c:v copy`, passing Google's H264 through untouched. Add `+genpts` and `-avoid_negative_ts make_zero` to the output streamer to handle timestamp discontinuities when transitioning from the static placeholder to the live feed.

### fix: pre-existing bug fixes
- Add explicit `Promise<void>` return type to `#rtspStart` so the recursive retry properly propagates
- Add `void` to fire-and-forget async calls in event handlers (`#rtspStart`, `#webrtcStart`, `#streamJpegToOutputStream` restart paths) to avoid unhandled rejection warnings
- Null-guard `#streamer` before `await` in RTSP and WebRTC exit handlers
- Close `#cameraSocket` and `#udpSocket` in `#gracefulExit` — both were leaked on every stream restart; promote local `udp` variable to `#udpSocket` class field to enable cleanup
- Add `.catch()` to `peerConnected.then()` so WebRTC connection errors surface in logs rather than silently swallowing

## Test plan
- [ ] Google OAuth callback with unknown parameters completes without `Auth data malformed` error
- [ ] NestMTX starts and connects to bundled MediaMTX without API client errors
- [ ] Static placeholder stream runs at reduced CPU compared to previous behaviour
- [ ] Live camera stream plays in UniFi Protect without freeze-frames or VBV underflow log errors
- [ ] Stream transitions cleanly from placeholder to live feed without timestamp discontinuities
- [ ] No socket/FD leaks observed across multiple stream restart cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)